### PR TITLE
Feature/list services

### DIFF
--- a/main.go
+++ b/main.go
@@ -35,6 +35,7 @@ func main() {
 
 		commands.NewGetLiveVariantCmd(deploySvc),
 		commands.NewTagImageCmd(deploySvc),
+		commands.NewListServicesCmd(deploySvc),
 
 		// TODO for Future
 		// commands.CreateTaskDefinition(deploySvc),

--- a/pkg/aws/ecs/ecs.go
+++ b/pkg/aws/ecs/ecs.go
@@ -10,6 +10,10 @@ import (
 	"fmt"
 )
 
+const (
+	descServiceLimit = 10 // describe operation takes max 10 service arns
+)
+
 type ECS interface {
 	DescribeServices() ([]*ecs.Service, error)
 	GetService(clusterName, serviceName *string) (*ecs.Service, error)
@@ -145,9 +149,8 @@ func (e ECSImpl) DescribeServices() ([]*ecs.Service, error) {
 		if err != nil {
 			return nil, err
 		}
-		// describe operation takes max 10 service arns
-		for i := 0; i < len(svcArns); i += 10 {
-			end := i + 10
+		for i := 0; i < len(svcArns); i += descServiceLimit {
+			end := i + descServiceLimit
 			if end > len(svcArns) {
 				end = len(svcArns)
 			}

--- a/pkg/aws/ecs/ecs.go
+++ b/pkg/aws/ecs/ecs.go
@@ -134,12 +134,8 @@ func (e ECSImpl) DescribeServices() ([]*ecs.Service, error) {
 	if err != nil {
 		return nil, err
 	}
-	if len(clsArns) == 0 {
-		return nil, fmt.Errorf("there is no clusters")
-	}
 
 	allSvc := make([]*ecs.Service, 0, 10)
-
 	for _, arn := range clsArns {
 		svcArns := make([]*string, 0, 10)
 		err := e.svc.ListServicesPages(&ecs.ListServicesInput{Cluster: arn}, func(page *ecs.ListServicesOutput, lastPage bool) bool {
@@ -149,9 +145,7 @@ func (e ECSImpl) DescribeServices() ([]*ecs.Service, error) {
 		if err != nil {
 			return nil, err
 		}
-		if len(svcArns) == 0 {
-			continue
-		}
+		// describe operation takes max 10 service arns
 		for i := 0; i < len(svcArns); i += 10 {
 			end := i + 10
 			if end > len(svcArns) {

--- a/pkg/commands/list_services_cmd.go
+++ b/pkg/commands/list_services_cmd.go
@@ -1,0 +1,23 @@
+package commands
+
+import (
+	"github.com/piotrjaromin/ecs-go/pkg/services"
+	"github.com/urfave/cli"
+)
+
+// NewListServicesCmd creates cli command for listing all ECS services from current region
+func NewListServicesCmd(deployment services.Deployment) cli.Command {
+	return cli.Command{
+		Name:    "list-services",
+		Aliases: []string{"ls"},
+		Usage:   "Gets list of services",
+		Action: func(c *cli.Context) error {
+			output, err := deployment.ListServices()
+			if err != nil {
+				return err
+			}
+
+			return printOutput(output)
+		},
+	}
+}

--- a/pkg/services/model.go
+++ b/pkg/services/model.go
@@ -30,3 +30,10 @@ type WaitForStateOutput struct {
 	Waited string `json:"waited"`
 	State  string `json:"state"`
 }
+
+type ListServicesItemOutput struct {
+	ServiceName    *string `json:"serviceName"`
+	ClusterArn     *string `json:"clusterArn"`
+	ContainerPort  *int64  `json:"containerPort"`
+	TargetGroupArn *string `json:"targetGroupArn"`
+}


### PR DESCRIPTION
Add command for listing services from all clusters. Current use case is to easy check what containerPorts are in use to help to avoid collisions in case of issues with ECS not de-registering stopped tasks from target group.